### PR TITLE
Add embedded files for ui

### DIFF
--- a/cmd/web/domain/error/error.domain.go
+++ b/cmd/web/domain/error/error.domain.go
@@ -3,6 +3,7 @@ package errorDomain
 import (
 	"GoBaby/internal/models"
 	"GoBaby/internal/utils"
+	"GoBaby/ui"
 	"fmt"
 	"net/http"
 )
@@ -12,10 +13,10 @@ func ErrorTemplate(w http.ResponseWriter, r *http.Request, errMsg *models.AppErr
 	w.Header().Add("HX-Reswap", "outerHTML")
 
 	w.WriteHeader(http.StatusOK)
-	file := "ui/html/pages/error/error.tmpl.html"
+	file := "html/pages/error/error.tmpl.html"
 
 	context := struct{ ErrorMessage string }{ErrorMessage: fmt.Sprint(errMsg)}
-	utils.ParseTemplateFiles(w, "error", context, utils.EmptyFuncMap, file)
+	utils.ParseTemplateFiles(w, "error", context, utils.EmptyFuncMap, ui.Content, file)
 }
 
 func ClearErrorTemplate(w http.ResponseWriter, r *http.Request) {
@@ -23,7 +24,7 @@ func ClearErrorTemplate(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("HX-Reswap", "outerHTML")
 
 	w.WriteHeader(http.StatusOK)
-	file := "ui/html/pages/error/clear-error.tmpl.html"
+	file := "html/pages/error/clear-error.tmpl.html"
 
-	utils.ParseTemplateFiles(w, "error", utils.EmptyStruct, utils.EmptyFuncMap, file)
+	utils.ParseTemplateFiles(w, "error", utils.EmptyStruct, utils.EmptyFuncMap, ui.Content, file)
 }

--- a/cmd/web/domain/log/log.domain.go
+++ b/cmd/web/domain/log/log.domain.go
@@ -5,6 +5,7 @@ import (
 	repository_domain "GoBaby/cmd/web/domain/repository"
 	"GoBaby/internal/models"
 	"GoBaby/internal/utils"
+	"GoBaby/ui"
 	"net/http"
 	"time"
 
@@ -22,7 +23,7 @@ func LogTable(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		errorDomain.ErrorTemplate(w, r, err)
 	} else {
-		utils.ParseTemplateFiles(w, "logTable", user.Logs, utils.EmptyFuncMap, "ui/html/pages/logs/logTable.tmpl.html")
+		utils.ParseTemplateFiles(w, "logTable", user.Logs, utils.EmptyFuncMap, ui.Content, "html/pages/logs/logTable.tmpl.html")
 	}
 }
 
@@ -32,11 +33,11 @@ func LogView(w http.ResponseWriter, r *http.Request) {
 	// use this utility if you are under a version lower than 1.7
 	if utils.IsValidHTTPMethod(r.Method, utils.GET.String(), w) {
 		files := []string{
-			"ui/html/base.html",
-			"ui/html/pages/logs/logs.tmpl.html",
+			"html/base.html",
+			"html/pages/logs/logs.tmpl.html",
 		}
 
-		utils.ParseTemplateFiles(w, "base", utils.EmptyStruct, utils.EmptyFuncMap, files...)
+		utils.ParseTemplateFiles(w, "base", utils.EmptyStruct, utils.EmptyFuncMap, ui.Content, files...)
 	}
 }
 

--- a/cmd/web/domain/main/clock.domain.go
+++ b/cmd/web/domain/main/clock.domain.go
@@ -23,7 +23,7 @@ func GetDuration() int {
 func ClockFragment(w http.ResponseWriter, r *http.Request) {
 	utils.CheckIfPath(w, r, models.RoutesInstance.CLOCK)
 
-	utils.ParseTemplateFiles(w, "clock", clockInstance, utils.EmptyFuncMap, "ui/html/pages/main/clock.tmpl.html")
+	utils.ParseTemplateFiles(w, "clock", clockInstance, utils.EmptyFuncMap, "html/pages/main/clock.tmpl.html")
 }
 
 func RestartCycle(w http.ResponseWriter, r *http.Request) {

--- a/cmd/web/domain/main/clock.domain.go
+++ b/cmd/web/domain/main/clock.domain.go
@@ -5,6 +5,7 @@ import (
 	logDomain "GoBaby/cmd/web/domain/log"
 	"GoBaby/internal/models"
 	"GoBaby/internal/utils"
+	"GoBaby/ui"
 	"net/http"
 )
 
@@ -23,7 +24,7 @@ func GetDuration() int {
 func ClockFragment(w http.ResponseWriter, r *http.Request) {
 	utils.CheckIfPath(w, r, models.RoutesInstance.CLOCK)
 
-	utils.ParseTemplateFiles(w, "clock", clockInstance, utils.EmptyFuncMap, "html/pages/main/clock.tmpl.html")
+	utils.ParseTemplateFiles(w, "clock", clockInstance, utils.EmptyFuncMap, ui.Content, "html/pages/main/clock.tmpl.html")
 }
 
 func RestartCycle(w http.ResponseWriter, r *http.Request) {

--- a/cmd/web/domain/main/main.domain.go
+++ b/cmd/web/domain/main/main.domain.go
@@ -10,8 +10,8 @@ func MainView(w http.ResponseWriter, r *http.Request) {
 	utils.CheckIfPath(w, r, models.RoutesInstance.MAIN)
 
 	files := []string{
-		"ui/html/base.html",
-		"ui/html/pages/main/main.tmpl.html",
+		"html/base.html",
+		"html/pages/main/main.tmpl.html",
 	}
 
 	utils.ParseTemplateFiles(w, "base", utils.EmptyStruct, utils.EmptyFuncMap, files...)

--- a/cmd/web/domain/main/main.domain.go
+++ b/cmd/web/domain/main/main.domain.go
@@ -3,6 +3,7 @@ package mainDomain
 import (
 	"GoBaby/internal/models"
 	"GoBaby/internal/utils"
+	"GoBaby/ui"
 	"net/http"
 )
 
@@ -14,5 +15,5 @@ func MainView(w http.ResponseWriter, r *http.Request) {
 		"html/pages/main/main.tmpl.html",
 	}
 
-	utils.ParseTemplateFiles(w, "base", utils.EmptyStruct, utils.EmptyFuncMap, files...)
+	utils.ParseTemplateFiles(w, "base", utils.EmptyStruct, utils.EmptyFuncMap, ui.Content, files...)
 }

--- a/cmd/web/routes/starter.route.go
+++ b/cmd/web/routes/starter.route.go
@@ -9,8 +9,7 @@ import (
 
 var (
 	mux        = http.NewServeMux()
-	static, _  = fs.Sub(ui.Content, "static")
-	fileServer = http.FileServerFS(static)
+	fileServer http.Handler
 )
 
 func GetMuxInstance() *http.ServeMux {
@@ -18,5 +17,10 @@ func GetMuxInstance() *http.ServeMux {
 }
 
 func GetFileServerInstance() http.Handler {
+	if fileServer == nil {
+		staticFS, _ := fs.Sub(ui.Content, "static")
+		fileServer = http.FileServerFS(staticFS)
+	}
+
 	return fileServer
 }

--- a/cmd/web/routes/starter.route.go
+++ b/cmd/web/routes/starter.route.go
@@ -1,10 +1,16 @@
 package routes
 
-import "net/http"
+import (
+	"io/fs"
+	"net/http"
+
+	"GoBaby/ui"
+)
 
 var (
 	mux        = http.NewServeMux()
-	fileServer = http.FileServer(http.Dir("ui/static"))
+	static, _  = fs.Sub(ui.Content, "static")
+	fileServer = http.FileServerFS(static)
 )
 
 func GetMuxInstance() *http.ServeMux {

--- a/internal/utils/template.go
+++ b/internal/utils/template.go
@@ -1,15 +1,14 @@
 package utils
 
 import (
+	"embed"
 	"fmt"
 	"html/template"
 	"net/http"
-
-	"GoBaby/ui"
 )
 
-func ParseTemplateFiles(w http.ResponseWriter, templateName string, context any, funcToTemplate template.FuncMap, files ...string) {
-	ts, er := template.ParseFS(ui.Content, files...)
+func ParseTemplateFiles(w http.ResponseWriter, templateName string, context any, funcToTemplate template.FuncMap, embedFS embed.FS, files ...string) {
+	ts, er := template.ParseFS(embedFS, files...)
 	if er != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		fmt.Println("Error parsing template files: ", er)

--- a/internal/utils/template.go
+++ b/internal/utils/template.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+
+	"GoBaby/ui"
 )
 
 func ParseTemplateFiles(w http.ResponseWriter, templateName string, context any, funcToTemplate template.FuncMap, files ...string) {
-	ts, er := template.ParseFiles(files...)
+	ts, er := template.ParseFS(ui.Content, files...)
 	if er != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		fmt.Println("Error parsing template files: ", er)

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -1,0 +1,6 @@
+package ui
+
+import "embed"
+
+//go:embed html/* static/*
+var Content embed.FS


### PR DESCRIPTION
Hola!

En Go existe la posibilidad de "embeber" los archivos estáticos (los archivos html, css, etc) dentro del mismo binario. Esto te brinda mas portabilidad y te evita estar moviendo todos los assets en una carpeta aparte.

Esto se hace utilizando la directiva `//go:embed` [doc](https://pkg.go.dev/embed).

Acá actualicé necesarios para su implementación.

Saludos!